### PR TITLE
Fixed weird decoration rendering on right-hand side of active windows

### DIFF
--- a/aurorae/McMojave/decoration.svg
+++ b/aurorae/McMojave/decoration.svg
@@ -12,49 +12,189 @@
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="355"
    height="310"
-   version="1.0"
-   id="svg199"
+   id="svg3642"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
    sodipodi:docname="decoration.svg"
-   inkscape:version="0.92.4 5da689c313, 2019-01-14">
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0"
+   inkscape:export-filename="/home/diau/svn/playground-plasma/desktoptheme/air/widgets/background.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
   <sodipodi:namedview
-     pagecolor="#2e2e2e"
+     id="base"
+     pagecolor="#eeeeee"
      bordercolor="#666666"
-     borderopacity="1"
-     objecttolerance="10"
-     gridtolerance="10"
-     guidetolerance="10"
+     borderopacity="1.0"
      inkscape:pageopacity="1"
      inkscape:pageshadow="2"
-     inkscape:window-width="1366"
-     inkscape:window-height="716"
-     id="namedview201"
-     showgrid="false"
-     inkscape:zoom="1.6903226"
-     inkscape:cx="468.08414"
-     inkscape:cy="154.18467"
-     inkscape:window-x="0"
-     inkscape:window-y="26"
-     inkscape:window-maximized="1"
-     inkscape:current-layer="svg199">
+     inkscape:zoom="1"
+     inkscape:cx="481.93169"
+     inkscape:cy="74.233981"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:window-width="1229"
+     inkscape:window-height="920"
+     inkscape:window-x="158"
+     inkscape:window-y="50"
+     width="48px"
+     height="48px"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     objecttolerance="9"
+     gridtolerance="13"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-nodes="true"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-midpoints="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-paths="true"
+     inkscape:snap-nodes="true">
     <inkscape:grid
        type="xygrid"
-       id="grid1192" />
+       id="grid2555"
+       enabled="true"
+       visible="true"
+       empspacing="5"
+       snapvisiblegridlinesonly="true" />
   </sodipodi:namedview>
   <defs
-     id="defs59">
+     id="defs3644">
     <linearGradient
-       id="linearGradient4192">
+       id="linearGradient4146">
       <stop
-         stop-color="#434343"
+         style="stop-color:#f5f5f5;stop-opacity:1"
          offset="0"
-         id="stop2" />
+         id="stop4142" />
       <stop
-         stop-color="#3d3d3d"
+         style="stop-color:#e2e2e2;stop-opacity:1"
          offset="1"
-         id="stop4" />
+         id="stop4144" />
     </linearGradient>
     <linearGradient
        id="linearGradient5391">
+      <stop
+         id="stop7028"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.92168677;" />
+      <stop
+         id="stop7026"
+         offset="0.125"
+         style="stop-color:#000000;stop-opacity:0.74096388;" />
+      <stop
+         id="stop6834"
+         offset="0.25"
+         style="stop-color:#000000;stop-opacity:0.60240966;" />
+      <stop
+         id="stop6832"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:0.33132529;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.10843374;"
+         offset="0.75"
+         id="stop6836" />
+      <stop
+         id="stop6894"
+         offset="0.875"
+         style="stop-color:#000000;stop-opacity:0.03921569;" />
+      <stop
+         id="stop6721"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5391-12">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop6719-25" />
+      <stop
+         id="stop6834-1"
+         offset="0.25"
+         style="stop-color:#000000;stop-opacity:0.63855422;" />
+      <stop
+         id="stop6832-0"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:0.33734939;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.10843374;"
+         offset="0.75"
+         id="stop6836-0" />
+      <stop
+         id="stop6894-7"
+         offset="0.875"
+         style="stop-color:#000000;stop-opacity:0.03921569;" />
+      <stop
+         id="stop6721-4"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7108">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop7110" />
+      <stop
+         id="stop7112-7"
+         offset="0.25"
+         style="stop-color:#000000;stop-opacity:0.63855422;" />
+      <stop
+         id="stop7114-9"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:0.33734939;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.10843374;"
+         offset="0.75"
+         id="stop7116" />
+      <stop
+         id="stop7118"
+         offset="0.875"
+         style="stop-color:#000000;stop-opacity:0.03921569;" />
+      <stop
+         id="stop7120-2"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5391-85">
+      <stop
+         id="stop7028-7"
+         offset="0"
+         style="stop-color:#000000;stop-opacity:0.92168677;" />
+      <stop
+         id="stop7026-85"
+         offset="0.125"
+         style="stop-color:#000000;stop-opacity:0.74096388;" />
+      <stop
+         id="stop6834-5"
+         offset="0.25"
+         style="stop-color:#000000;stop-opacity:0.60240966;" />
+      <stop
+         id="stop6832-01"
+         offset="0.5"
+         style="stop-color:#000000;stop-opacity:0.33132529;" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.10843374;"
+         offset="0.75"
+         id="stop6836-3" />
+      <stop
+         id="stop6894-2"
+         offset="0.875"
+         style="stop-color:#000000;stop-opacity:0.03921569;" />
+      <stop
+         id="stop6721-61"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient5391-3">
       <stop
          stop-opacity=".92169"
          offset="0"
@@ -84,6 +224,15 @@
          offset="1"
          id="stop19" />
     </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient1028"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.8857,-2.6521e-4,3.0788e-4,-4.45,297.51,991.4)"
+       cx="48.271"
+       cy="177.38"
+       r="17.5" />
     <linearGradient
        id="linearGradient5688"
        x1="398"
@@ -92,7 +241,54 @@
        y2="220.94"
        gradientTransform="translate(200,14)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5391" />
+       xlink:href="#linearGradient5391-3" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient167"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.8857,-2.6521e-4,3.0788e-4,-4.45,297.51,991.4)"
+       cx="48.271"
+       cy="177.38"
+       r="17.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient185"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.8857,-2.6521e-4,3.0788e-4,-4.45,297.51,991.4)"
+       cx="48.271"
+       cy="177.38"
+       r="17.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient1032"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0442e-6,-2.9179,-4,1.2788e-6,576.67,981.08)"
+       cx="296.48001"
+       cy="80.417"
+       r="17.5" />
+    <linearGradient
+       id="linearGradient4192">
+      <stop
+         stop-color="#434343"
+         offset="0"
+         id="stop2" />
+      <stop
+         stop-color="#3d3d3d"
+         offset="1"
+         id="stop4" />
+    </linearGradient>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient260"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0442e-6,-2.9179,-4,1.2788e-6,576.67,981.08)"
+       cx="296.48001"
+       cy="80.417"
+       r="17.5" />
     <linearGradient
        id="linearGradient6612"
        x1="396"
@@ -101,7 +297,63 @@
        y2="14.938"
        gradientTransform="translate(200,5)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5391" />
+       xlink:href="#linearGradient5391-3" />
+    <linearGradient
+       id="linearGradient7313"
+       x1="470"
+       x2="470"
+       y1="43"
+       y2="68.133003"
+       gradientTransform="matrix(1,0,0,1.0345,-85,131.52)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient4192" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient310"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0442e-6,-2.9179,-4,1.2788e-6,576.67,981.08)"
+       cx="296.48001"
+       cy="80.417"
+       r="17.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-3"
+       id="linearGradient398"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(175.12,14)"
+       x1="349.88"
+       y1="99"
+       x2="279.88"
+       y2="98.938004" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient400"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-3.8857,-2.6521e-4,3.0788e-4,-4.45,297.51,991.4)"
+       cx="48.271"
+       cy="177.38"
+       r="17.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient402"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1.0442e-6,-2.9179,-4,1.2788e-6,576.67,981.08)"
+       cx="296.48001"
+       cy="80.417"
+       r="17.5" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4192"
+       id="linearGradient404"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1,0,0,1.0345,-495,-9.1724)"
+       x1="760"
+       y1="92"
+       x2="760"
+       y2="117.13" />
     <linearGradient
        id="linearGradient5688-2"
        x1="398"
@@ -110,9 +362,9 @@
        y2="170.94"
        gradientTransform="translate(0,139.92)"
        gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5391-12" />
+       xlink:href="#linearGradient5391-12-3" />
     <linearGradient
-       id="linearGradient5391-12">
+       id="linearGradient5391-12-3">
       <stop
          offset="0"
          id="stop26" />
@@ -137,56 +389,9 @@
          offset="1"
          id="stop36" />
     </linearGradient>
-    <linearGradient
-       id="linearGradient6612-5"
-       x1="396"
-       x2="396"
-       y1="66"
-       y2="29.938"
-       gradientTransform="translate(200,5)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient5391-12" />
-    <linearGradient
-       id="linearGradient7313"
-       x1="470"
-       x2="470"
-       y1="43"
-       y2="68.133"
-       gradientTransform="matrix(1,0,0,1.0345,-85,131.52)"
-       gradientUnits="userSpaceOnUse"
-       xlink:href="#linearGradient4192" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5391"
-       id="linearGradient1022"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(175.12,14)"
-       x1="349.88"
-       y1="99"
-       x2="279.88"
-       y2="98.938" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5391-12"
-       id="linearGradient1024"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(175.12,14)"
-       x1="349.88"
-       y1="99"
-       x2="304.88"
-       y2="98.938" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient5391"
-       id="radialGradient1028"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-3.8857,-2.6521e-4,3.0788e-4,-4.45,297.51,991.4)"
-       cx="48.271"
-       cy="177.38"
-       r="17.5" />
-    <radialGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5391"
+       xlink:href="#linearGradient5391-3"
        id="radialGradient1030"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-2.5714,-2.643e-4,1.6478e-4,-1.5997,594.1,485.83)"
@@ -195,54 +400,87 @@
        r="17.5" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient5391"
-       id="radialGradient1032"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient141"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(-1.0442e-6,-2.9179,-4,1.2788e-6,576.67,981.08)"
-       cx="296.48"
-       cy="80.417"
+       gradientTransform="matrix(-2.5714,-2.643e-4,1.6478e-4,-1.5997,594.1,485.83)"
+       cx="48.271"
+       cy="177.38"
+       r="17.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient159"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.5714,-2.643e-4,1.6478e-4,-1.5997,594.1,485.83)"
+       cx="48.271"
+       cy="177.38"
+       r="17.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-12"
+       id="radialGradient1188"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.7484752e-7,-2.0606878,2.5714318,-7.5962304e-7,398.21419,731.89304)"
+       cx="296.45123"
+       cy="80.416672"
+       fx="296.45123"
+       fy="80.416672"
+       r="17.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-12"
+       id="radialGradient232"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.7484752e-7,-2.0606878,2.5714318,-7.5962304e-7,398.21419,731.89304)"
+       cx="296.45123"
+       cy="80.416672"
+       fx="296.45123"
+       fy="80.416672"
+       r="17.5" />
+    <linearGradient
+       id="linearGradient6612-5"
+       x1="396"
+       x2="396"
+       y1="66"
+       y2="29.938"
+       gradientTransform="translate(200,5)"
+       gradientUnits="userSpaceOnUse"
+       xlink:href="#linearGradient5391-12-3" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-12"
+       id="radialGradient263"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-5.7484752e-7,-2.0606878,2.5714318,-7.5962304e-7,398.21419,731.89304)"
+       cx="296.45123"
+       cy="80.416672"
+       fx="296.45123"
+       fy="80.416672"
        r="17.5" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient4192"
-       id="linearGradient1034"
+       xlink:href="#linearGradient5391-12-3"
+       id="linearGradient361"
        gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,1.0345,-495,-9.1724)"
-       x1="760"
-       y1="92"
-       x2="760"
-       y2="117.13" />
-    <linearGradient
-       id="linearGradient7108">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop7110" />
-      <stop
-         id="stop7112-7"
-         offset="0.25"
-         style="stop-color:#000000;stop-opacity:0.63855422;" />
-      <stop
-         id="stop7114-9"
-         offset="0.5"
-         style="stop-color:#000000;stop-opacity:0.33734939;" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0.10843374;"
-         offset="0.75"
-         id="stop7116" />
-      <stop
-         id="stop7118"
-         offset="0.875"
-         style="stop-color:#000000;stop-opacity:0.03921569;" />
-      <stop
-         id="stop7120-2"
-         offset="1"
-         style="stop-color:#000000;stop-opacity:0;" />
-    </linearGradient>
+       gradientTransform="translate(175.12,14)"
+       x1="349.88"
+       y1="99"
+       x2="304.88"
+       y2="98.938004" />
     <radialGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient7108"
-       id="radialGradient1188"
+       xlink:href="#linearGradient5391-3"
+       id="radialGradient363"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-2.5714,-2.643e-4,1.6478e-4,-1.5997,594.1,485.83)"
+       cx="48.271"
+       cy="177.38"
+       r="17.5" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient5391-12"
+       id="radialGradient365"
        gradientUnits="userSpaceOnUse"
        gradientTransform="matrix(-5.7484752e-7,-2.0606878,2.5714318,-7.5962304e-7,398.21419,731.89304)"
        cx="296.45123"
@@ -252,14 +490,14 @@
        r="17.5" />
   </defs>
   <metadata
-     id="metadata61">
+     id="metadata3647">
     <rdf:RDF>
       <cc:Work
          rdf:about="">
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
       <cc:Work
          rdf:about="">
@@ -269,391 +507,567 @@
       </cc:Work>
     </rdf:RDF>
   </metadata>
-  <use
-     y="0"
-     x="0"
-     xlink:href="#decoration-left"
-     height="100%"
-     width="100%"
-     transform="matrix(-1,0,0,1,365,0)"
-     id="decoration-right" />
   <g
-     transform="translate(-215,-81)"
-     id="decoration-bottom">
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.85;fill:url(#linearGradient5688)"
-       id="path82"
-       d="m 525,164 v 85 h 145 v -85 z"
-       transform="translate(-200,126)" />
-    <path
-       style="opacity:0.80699989"
-       inkscape:connector-curvature="0"
-       id="path84"
-       d="M 470,289 H 325 v 1 h 145 z" />
-    <path
-       style="opacity:0.8;fill:#242424"
-       inkscape:connector-curvature="0"
-       id="path86"
-       d="M 470,143 H 325 v 6 h 145 z"
-       transform="translate(0,140)" />
-  </g>
-  <path
-     style="fill:#3e3e3e"
-     inkscape:connector-curvature="0"
-     d="m 110,116 v 86 h 145 v -86 z"
-     id="decoration-center" />
-  <g
-     transform="translate(-215,-89.99995)"
-     id="decoration-top">
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.85;fill:url(#linearGradient6612)"
-       id="path90"
-       d="M 525,5 V 40 H 670 V 5 Z"
-       transform="translate(-200,135)" />
-    <path
-       style="opacity:0.803"
-       inkscape:connector-curvature="0"
-       id="path92"
-       d="M 325,35 V 57 H 470 V 35 Z"
-       transform="translate(0,140)" />
-    <path
-       inkscape:connector-curvature="0"
-       style="fill:url(#linearGradient7313)"
-       id="path94"
-       d="m 325,176 v 30 h 145 v -30 z" />
-    <path
-       style="opacity:0.1;fill:#ffffff"
-       inkscape:connector-curvature="0"
-       id="path96"
-       d="m 325,176 v 1 h 145 v -1 z" />
-  </g>
-  <g
-     transform="translate(-239.88,-81)"
-     id="decoration-left">
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.85;fill:url(#linearGradient1022)"
-       id="path99"
-       d="m 420,71 v 86 h 75 V 71 Z"
-       transform="translate(-175.12,126)" />
-    <path
-       style="opacity:0.85"
-       inkscape:connector-curvature="0"
-       id="path101"
-       d="m 319.88,197 v 86 h 5 v -86 z" />
+     id="layer1"
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     transform="translate(0,-90)">
+    <g
+       transform="translate(-1453.4451,-465.21909)"
+       inkscape:label="layer1"
+       style="display:none"
+       id="g4418" />
+    <g
+       transform="translate(-1453.4451,-465.21909)"
+       inkscape:label="glow"
+       style="display:inline"
+       id="layer2" />
+    <g
+       inkscape:label="layer1"
+       style="display:none"
+       id="g2424"
+       transform="translate(975.61592,-1945.0985)" />
+    <g
+       inkscape:label="glow"
+       style="display:inline"
+       id="g2426"
+       transform="translate(975.61592,-1945.0985)" />
+    <g
+       inkscape:label="Layer 1"
+       id="g3429"
+       transform="translate(1021.5937,-976.23581)" />
+    <g
+       inkscape:label="Layer 1"
+       id="g19758"
+       transform="translate(2807.8842,-592.77773)" />
+    <g
+       inkscape:label="Layer 1"
+       id="g3935"
+       transform="translate(3912.7094,-1471.0471)" />
+    <g
+       inkscape:label="Layer 1"
+       id="g8459"
+       transform="translate(1514.8397,-1486.3943)" />
+    <g
+       inkscape:label="Layer 1"
+       id="g28391"
+       transform="translate(164.02222,-157.78265)" />
+    <g
+       inkscape:label="Layer 1"
+       id="g28393"
+       transform="translate(1268.8474,-1036.052)" />
+    <g
+       inkscape:label="Layer 1"
+       id="g28395"
+       transform="translate(-1129.0223,-1051.3992)" />
+    <g
+       inkscape:label="Layer 1"
+       id="g6598"
+       transform="translate(2310.5222,-165.78265)" />
+    <g
+       inkscape:label="Layer 1"
+       id="g6640"
+       transform="translate(3415.3474,-1044.052)" />
+    <g
+       inkscape:label="Layer 1"
+       id="g6716"
+       transform="translate(1017.4777,-1059.3992)" />
+    <g
+       id="g6850"
+       transform="matrix(1,0,0,-1,-153.44508,295.17435)"
+       style="opacity:0.45945943" />
+    <text
+       xml:space="preserve"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'Gill Sans';text-align:justify;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       x="70.554916"
+       y="-207.8569"
+       id="text6990"><tspan
+         sodipodi:role="line"
+         id="tspan6992"
+         x="70.554916"
+         y="-207.8569"
+         style="font-size:14px;line-height:1.25"> </tspan></text>
+    <g
+       id="g4240"
+       style="display:none"
+       inkscape:label="layer1"
+       transform="translate(-1919.565,-153.36219)" />
+    <g
+       id="g4242"
+       style="display:inline"
+       inkscape:label="glow"
+       transform="translate(-1919.565,-153.36219)" />
+    <g
+       transform="translate(509.49601,-1633.2416)"
+       id="g4244"
+       style="display:none"
+       inkscape:label="layer1" />
+    <g
+       transform="translate(509.49601,-1633.2416)"
+       id="g4246"
+       style="display:inline"
+       inkscape:label="glow" />
+    <g
+       transform="translate(555.47381,-664.37887)"
+       id="g4248"
+       inkscape:label="Layer 1" />
+    <g
+       transform="translate(2341.7643,-280.92083)"
+       id="g4250"
+       inkscape:label="Layer 1" />
+    <g
+       transform="translate(3446.5895,-1159.1902)"
+       id="g4252"
+       inkscape:label="Layer 1" />
+    <g
+       transform="translate(1048.7198,-1174.5374)"
+       id="g4254"
+       inkscape:label="Layer 1" />
+    <g
+       transform="translate(-302.09768,154.07425)"
+       id="g4256"
+       inkscape:label="Layer 1" />
+    <g
+       transform="translate(802.72751,-724.19507)"
+       id="g4258"
+       inkscape:label="Layer 1" />
+    <g
+       transform="translate(-1595.1422,-739.54227)"
+       id="g4260"
+       inkscape:label="Layer 1" />
+    <g
+       transform="translate(1844.4023,146.07425)"
+       id="g4262"
+       inkscape:label="Layer 1" />
+    <g
+       transform="translate(2949.2275,-732.19507)"
+       id="g4264"
+       inkscape:label="Layer 1" />
+    <g
+       transform="translate(551.35781,-747.54227)"
+       id="g4266"
+       inkscape:label="Layer 1" />
+    <g
+       style="opacity:0.45945943"
+       transform="matrix(1,0,0,-1,-619.56498,607.03125)"
+       id="g4268" />
+    <text
+       id="text4270"
+       y="104.00001"
+       x="-395.565"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'Gill Sans';text-align:justify;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke:none"
+       xml:space="preserve"><tspan
+         y="104.00001"
+         x="-395.565"
+         id="tspan4272"
+         sodipodi:role="line"
+         style="font-size:14px;line-height:1.25"> </tspan></text>
+    <text
+       id="text10408"
+       y="-270.00696"
+       x="416.03189"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Arial;-inkscape-font-specification:Arial;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:0.7486911;stroke:none"
+       xml:space="preserve"><tspan
+         y="-270.00696"
+         x="416.03189"
+         id="tspan10410"
+         sodipodi:role="line"
+         style="font-size:12px;line-height:1"> </tspan></text>
+    <text
+       id="text13129"
+       y="-175.93504"
+       x="461.32416"
+       style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:Arial;-inkscape-font-specification:Arial;text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#ffffff;fill-opacity:0.7486911;stroke:none"
+       xml:space="preserve"><tspan
+         y="-175.93504"
+         x="461.32416"
+         id="tspan13131"
+         sodipodi:role="line"
+         style="font-size:12px;line-height:1"> </tspan></text>
+    <g
+       transform="translate(-215,9)"
+       id="decoration-bottom">
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.85;fill:url(#linearGradient5688)"
+         id="path82"
+         d="m 525,164 v 85 h 145 v -85 z"
+         transform="translate(-200,126)" />
+      <path
+         style="opacity:0.80699978"
+         inkscape:connector-curvature="0"
+         id="path84"
+         d="M 470,289 H 325 v 1 h 145 z" />
+      <path
+         style="opacity:0.8;fill:#242424"
+         inkscape:connector-curvature="0"
+         id="path86"
+         d="M 470,143 H 325 v 6 h 145 z"
+         transform="translate(0,140)" />
+    </g>
     <path
        style="fill:#3e3e3e"
        inkscape:connector-curvature="0"
-       id="path103"
-       d="m 576,121 v 86 h 29 v -86 z"
-       transform="translate(-255.12,76)" />
-  </g>
-  <g
-     transform="translate(145,-80.922)"
-     id="decoration-inactive-bottom">
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.85;fill:url(#linearGradient5688-2)"
-       id="path106"
-       d="m 325,289.92 v 85 h 145 v -85 z" />
-    <path
-       style="opacity:0.80699989"
-       inkscape:connector-curvature="0"
-       id="path108"
-       d="M 470,288.92 H 325 v 1 h 145 z" />
-    <path
-       style="opacity:0.8;fill:#242424"
-       inkscape:connector-curvature="0"
-       id="path110"
-       d="M 470,282.92 H 325 v 6 h 145 z" />
-  </g>
-  <path
-     style="fill:#3e3e3e"
-     inkscape:connector-curvature="0"
-     d="m 470,116 v 86 h 145 v -86 z"
-     id="decoration-inactive-center" />
-  <g
-     transform="translate(145,-90)"
-     id="decoration-inactive-top">
+       d="m 110,206 v 86 h 145 v -86 z"
+       id="decoration-center" />
     <g
-       id="g120">
+       transform="translate(-215,5e-5)"
+       id="decoration-top">
       <path
          inkscape:connector-curvature="0"
-         style="opacity:0.85;fill:url(#linearGradient6612-5)"
-         id="path114"
+         style="opacity:0.85;fill:url(#linearGradient6612)"
+         id="path90"
          d="M 525,5 V 40 H 670 V 5 Z"
          transform="translate(-200,135)" />
       <path
-         style="opacity:0.85"
+         style="opacity:0.803"
          inkscape:connector-curvature="0"
-         id="path116"
+         id="path92"
          d="M 325,35 V 57 H 470 V 35 Z"
          transform="translate(0,140)" />
       <path
-         style="fill:#2d2d2d"
          inkscape:connector-curvature="0"
-         id="path118"
+         style="fill:url(#linearGradient7313)"
+         id="path94"
          d="m 325,176 v 30 h 145 v -30 z" />
+      <path
+         style="opacity:0.1;fill:#ffffff"
+         inkscape:connector-curvature="0"
+         id="path96"
+         d="m 325,176 v 1 h 145 v -1 z" />
     </g>
-    <path
-       style="opacity:0.07999998;fill:#ffffff;fill-opacity:0.99492002"
-       inkscape:connector-curvature="0"
-       id="path122"
-       d="m 325,176 v 1 h 145 v -1 z" />
-  </g>
-  <g
-     transform="translate(120.12,-81.0155)"
-     id="decoration-inactive-left">
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.85;fill:url(#linearGradient1024)"
-       id="path125"
-       d="m 420,71.015 v 86 h 75 v -86 z"
-       transform="translate(-175.12,126)" />
-    <path
-       style="opacity:0.85"
-       inkscape:connector-curvature="0"
-       id="path127"
-       d="m 319.88,197.02 v 86 h 5 v -86 z" />
-    <path
-       style="fill:#3e3e3e"
-       inkscape:connector-curvature="0"
-       id="path129"
-       d="m 320.88,197.02 v 86 h 29 v -86 z" />
-  </g>
-  <g
-     transform="translate(-385,-94)"
-     id="decoration-bottomleft">
     <g
-       id="g149"
-       transform="matrix(1,0,0,0.99932,165,-10.667)">
+       transform="translate(-239.88,9)"
+       id="decoration-left">
       <path
          inkscape:connector-curvature="0"
-         style="opacity:0.85;fill:url(#radialGradient1028)"
-         id="path145"
-         d="m 5,202.06 v 92 l 105,-0.0625 v -84.938 L 87,208.997 c -3.8569,0 -6.9623,-3.0889 -6.9961,-6.9375 H 80 Z"
-         transform="matrix(1,0,0,1.0007,220,104.68)" />
-      <g
-         id="g147"
-         transform="translate(-20,24)" />
-    </g>
-    <path
-       style="opacity:0.85"
-       inkscape:connector-curvature="0"
-       id="path151"
-       d="m 80.004,202.06 c 0.03379,3.8486 3.1392,7 6.9961,7 l 23,1e-5 v -1 h -23 c -3.324,0 -6,-2.676 -6,-6 z"
-       transform="translate(385,93.938)" />
-    <path
-       style="opacity:0.8;fill:#242424"
-       inkscape:connector-curvature="0"
-       id="path153"
-       d="m 81,202.06 c 0,3.324 2.676,6 6,6 h 23 v -6 z"
-       transform="translate(385,93.938)" />
-  </g>
-  <g
-     id="decoration-inactive-bottomleft"
-     transform="translate(0,-90)">
-    <g
-       id="g160"
-       transform="matrix(1,0,0,0.99932,140,-14.604)">
+         style="opacity:0.85;fill:url(#linearGradient398)"
+         id="path99"
+         d="m 420,71 v 86 h 75 V 71 Z"
+         transform="translate(-175.12,126)" />
       <path
+         style="opacity:0.85"
          inkscape:connector-curvature="0"
-         style="opacity:0.85;fill:url(#radialGradient1030)"
-         id="path156"
-         d="m 365,202 v 91.937 l 105,0.0625 v -85.062 l -23.004,1e-5 c -3.8318,0 -6.919,-3.1113 -6.9922,-6.9258 l -0.004,-0.0117 z"
-         transform="matrix(1,0,0,1.0007,-140,104.68)" />
-      <g
-         id="g158"
-         transform="translate(-20,24)" />
+         id="path101"
+         d="m 319.88,197 v 86 h 5 v -86 z" />
+      <path
+         style="fill:#3e3e3e"
+         inkscape:connector-curvature="0"
+         id="path103"
+         d="m 576,121 v 86 h 29 v -86 z"
+         transform="translate(-255.12,76)" />
     </g>
-    <path
-       style="opacity:0.85"
-       inkscape:connector-curvature="0"
-       id="path162"
-       d="m 440,292.01 c 0.0338,3.8486 3.1392,7 6.9961,7 l 23,1e-5 v -1 h -23 c -3.324,0 -6,-2.676 -6,-6 z" />
-    <path
-       style="opacity:0.8;fill:#242424"
-       inkscape:connector-curvature="0"
-       id="path164"
-       d="m 441,292 c 0,3.324 2.676,6 6,6 h 23 v -6 z" />
-  </g>
-  <g
-     style="fill:#ff00ff"
-     id="g171"
-     transform="translate(0,-90)">
-    <rect
-       height="36"
-       width="4"
-       y="140"
-       x="174"
-       id="shadow-hint-top-margin" />
-    <rect
-       height="86"
-       width="4"
-       y="298"
-       x="175"
-       id="shadow-hint-bottom-margin" />
-    <rect
-       height="4"
-       width="76"
-       y="236"
-       x="284"
-       id="shadow-hint-right-margin" />
-    <rect
-       height="4"
-       width="76"
-       y="230"
-       x="5"
-       id="shadow-hint-left-margin" />
-  </g>
-  <g
-     style="fill:#00ff29"
-     id="g177"
-     transform="translate(0,-90)">
-    <rect
-       height="66"
-       width="4"
-       y="140"
-       x="186"
-       id="hint-top-margin" />
-    <rect
-       height="92"
-       width="4"
-       y="292"
-       x="187"
-       id="hint-bottom-margin" />
-    <rect
-       height="105"
-       width="4"
-       y="-360"
-       x="225"
-       transform="rotate(90)"
-       id="hint-right-margin" />
-    <rect
-       height="104.88"
-       width="4"
-       y="-110"
-       x="222"
-       transform="rotate(90)"
-       id="hint-left-margin" />
-  </g>
-  <g
-     transform="matrix(-1,0,0,1,535,-115.062)"
-     id="decoration-topleft">
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.85;fill:url(#radialGradient1032)"
-       id="path179"
-       d="m 255,50 v 35 h 23 c 3.878,0 7,3.122 7,7 v 24 h 75 V 50 Z"
-       transform="translate(170,115.06)" />
     <g
-       id="g189"
-       transform="translate(250)">
+       transform="translate(-385,-4)"
+       id="decoration-bottomleft">
       <g
-         id="g187"
-         transform="matrix(-1,0,0,1,524,26)">
-        <path
-           style="opacity:0.8"
-           inkscape:connector-curvature="0"
-           id="path181"
-           d="m 255,85 v 31 h 30 V 92 c 0,-3.878 -3.122,-7 -7,-7 h -3 z"
-           transform="matrix(-1,0,0,1,604,89.062)" />
+         id="g149"
+         transform="matrix(1,0,0,0.99932,165,-10.667)">
         <path
            inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient1034)"
-           id="path183"
-           d="m 255,86 v 30 h 29 V 92 c 0,-3.324 -2.676,-6 -6,-6 z"
-           transform="matrix(-1,0,0,1,604,89.062)" />
-        <path
-           style="opacity:0.1;fill:#ffffff"
-           inkscape:connector-curvature="0"
-           id="path185"
-           d="m 87,86 c -3.324,0 -6,2.676 -6,6 v 0.80078 c 0,-3.2132 2.676,-5.8008 6,-5.8008 h 23 v -1 z"
-           transform="translate(239,89.062)" />
-      </g>
-    </g>
-  </g>
-  <use
-     y="0"
-     x="0"
-     xlink:href="#decoration-topleft"
-     height="100%"
-     width="100%"
-     transform="matrix(-1,0,0,1,365,0)"
-     id="decoration-topright" />
-  <use
-     y="0"
-     x="0"
-     xlink:href="#decoration-bottomleft"
-     height="100%"
-     width="100%"
-     transform="matrix(-1,0,0,1,365,0)"
-     id="decoration-bottomright" />
-  <use
-     y="0"
-     x="0"
-     xlink:href="#decoration-inactive-left"
-     height="100%"
-     width="100%"
-     transform="matrix(-1,0,0,1,1085,0)"
-     id="decoration-inactive-right" />
-  <use
-     y="0"
-     x="0"
-     xlink:href="#decoration-inactive-bottomleft"
-     height="100%"
-     width="100%"
-     transform="matrix(-1,0,0,1,1085,0)"
-     id="decoration-inactive-bottomright" />
-  <g
-     id="decoration-inactive-topleft"
-     inkscape:label="#decoration-inactive-topleft"
-     transform="translate(140,-115.063)">
-    <path
-       inkscape:connector-curvature="0"
-       style="opacity:0.85;fill:url(#radialGradient1188);fill-opacity:1;stroke:none"
-       d="m 518,54.9375 c -9.972,0 -18,8.028 -18,18 v 12 9 1 2 15 V 120 120.9375 121 h 75 V 120.9375 120 111.9375 95 c 0,-2.77 2.23,-5 5,-5 h 10 10 5 V 55 h -5 V 54.9375 H 590 V 55 h -10 v -0.0625 h -18 -2 z"
-       transform="translate(-275,110.063)"
-       id="rect6520-3-2-6" />
-    <g
-       inkscape:label="#g5343"
-       id="6utrh-9">
-      <g
-         id="decoration-toplefthaerty-5"
-         inkscape:label="#g5253"
-         transform="translate(0,1)">
+           style="opacity:0.85;fill:url(#radialGradient400)"
+           id="path145"
+           d="m 5,202.06 v 92 l 105,-0.0625 v -84.938 L 87,208.997 c -3.8569,0 -6.9623,-3.0889 -6.9961,-6.9375 H 80 Z"
+           transform="matrix(1,0,0,1.0007,220,104.68)" />
         <g
-           inkscape:label="#g6458"
-           transform="translate(-19,25)"
-           id="49093u-9">
+           id="g147"
+           transform="translate(-20,24)" />
+      </g>
+      <path
+         style="opacity:0.85"
+         inkscape:connector-curvature="0"
+         id="path151"
+         d="m 80.004,202.06 c 0.03379,3.8486 3.1392,7 6.9961,7 l 23,1e-5 v -1 h -23 c -3.324,0 -6,-2.676 -6,-6 z"
+         transform="translate(385,93.938)" />
+      <path
+         style="opacity:0.8;fill:#242424"
+         inkscape:connector-curvature="0"
+         id="path153"
+         d="m 81,202.06 c 0,3.324 2.676,6 6,6 h 23 v -6 z"
+         transform="translate(385,93.938)" />
+    </g>
+    <g
+       transform="matrix(-1,0,0,1,535,-25.062)"
+       id="decoration-topleft">
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.85;fill:url(#radialGradient402)"
+         id="path179"
+         d="m 255,50 v 35 h 23 c 3.878,0 7,3.122 7,7 v 24 h 75 V 50 Z"
+         transform="translate(170,115.06)" />
+      <g
+         id="g189"
+         transform="translate(250)">
+        <g
+           id="g187"
+           transform="matrix(-1,0,0,1,524,26)">
           <path
-             id="path1190"
-             d="m 325.23333,174.063 c -3.4348,0 -6.2,2.7652 -6.2,6.2 v 15.1125 0.0666 8.55123 1.00307 0.0666 h 24.8 H 349 V 203.99333 174.063 h -15.5 z"
-             style="fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.0333333;opacity:0.85"
-             inkscape:connector-curvature="0" />
+             style="opacity:0.8"
+             inkscape:connector-curvature="0"
+             id="path181"
+             d="m 255,85 v 31 h 30 V 92 c 0,-3.878 -3.122,-7 -7,-7 h -3 z"
+             transform="matrix(-1,0,0,1,604,89.062)" />
           <path
              inkscape:connector-curvature="0"
-             style="fill:#2d2d2d;fill-opacity:1;stroke:none;stroke-width:1"
-             d="m 447,86 c -3.324,0 -6,2.676 -6,6 v 14.625 0.0644 8.27539 0.97071 V 116 h 24 5 V 114.96484 86 h -15 z"
-             transform="translate(-121,89.063)"
-             id="rect5073-4-9-6" />
+             style="fill:url(#linearGradient404)"
+             id="path183"
+             d="m 255,86 v 30 h 29 V 92 c 0,-3.324 -2.676,-6 -6,-6 z"
+             transform="matrix(-1,0,0,1,604,89.062)" />
           <path
-             style="fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1;opacity:0.08"
-             d="M 447 86 C 443.676 86 441 88.676 441 92 L 441 92.800781 C 441 89.587581 443.676 87 447 87 L 455 87 L 470 87 L 470 86 L 455 86 L 447 86 z "
-             transform="translate(-121,89.063)"
-             id="path1194" />
+             style="opacity:0.1;fill:#ffffff"
+             inkscape:connector-curvature="0"
+             id="path185"
+             d="m 87,86 c -3.324,0 -6,2.676 -6,6 v 0.80078 c 0,-3.2132 2.676,-5.8008 6,-5.8008 h 23 v -1 z"
+             transform="translate(239,89.062)" />
         </g>
       </g>
     </g>
+    <rect
+       style="opacity:1;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:0.44721359"
+       id="shadow-hint-top-margin"
+       width="4"
+       height="35.999897"
+       x="174"
+       y="140.00005" />
+    <use
+       y="0"
+       x="0"
+       xlink:href="#decoration-topleft"
+       height="100%"
+       width="100%"
+       transform="matrix(-1,0,0,1,365,0)"
+       id="decoration-topright" />
+    <rect
+       style="opacity:1;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:1.18321598"
+       id="shadow-hint-bottom-margin"
+       width="4"
+       height="85.999969"
+       x="175"
+       y="298.00003" />
+    <use
+       y="0"
+       x="0"
+       xlink:href="#decoration-bottomleft"
+       height="100%"
+       width="100%"
+       transform="matrix(-1,0,0,1,365,0)"
+       id="decoration-bottomright" />
+    <use
+       y="0"
+       x="0"
+       xlink:href="#decoration-left"
+       height="100%"
+       width="100%"
+       transform="matrix(-1,0,0,1,365,0)"
+       id="decoration-right" />
+    <rect
+       style="opacity:1;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:0.70710677"
+       id="shadow-hint-right-margin"
+       width="76"
+       height="4"
+       x="284"
+       y="236" />
+    <rect
+       style="opacity:1;fill:#ff00ff;fill-opacity:1;stroke:none;stroke-width:0.70710677"
+       id="shadow-hint-left-margin"
+       width="76"
+       height="4"
+       x="5"
+       y="230" />
+    <rect
+       id="hint-top-margin"
+       width="4"
+       height="66"
+       x="186"
+       y="140"
+       style="fill:#00ff29;fill-opacity:1;stroke:none;stroke-width:1.0846523" />
+    <rect
+       id="hint-bottom-margin"
+       width="4"
+       height="91.999992"
+       x="187"
+       y="292"
+       style="fill:#00ff29;fill-opacity:1;stroke:none;stroke-width:1.0846523" />
+    <rect
+       id="hint-right-margin"
+       width="4"
+       height="105"
+       x="225"
+       y="-360"
+       transform="rotate(90)"
+       style="fill:#00ff29;fill-opacity:1;stroke:none;stroke-width:1.0846523" />
+    <rect
+       id="hint-left-margin"
+       width="4"
+       height="104.875"
+       x="222"
+       y="-110"
+       transform="rotate(90)"
+       style="fill:#00ff29;fill-opacity:1;stroke:none;stroke-width:1.0846523" />
+    <g
+       transform="translate(145,9.078)"
+       id="decoration-inactive-bottom">
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.85;fill:url(#linearGradient5688-2)"
+         id="path106"
+         d="m 325,289.92 v 85 h 145 v -85 z" />
+      <path
+         style="opacity:0.80699978"
+         inkscape:connector-curvature="0"
+         id="path108"
+         d="M 470,288.92 H 325 v 1 h 145 z" />
+      <path
+         style="opacity:0.8;fill:#242424"
+         inkscape:connector-curvature="0"
+         id="path110"
+         d="M 470,282.92 H 325 v 6 h 145 z" />
+    </g>
+    <path
+       style="fill:#3e3e3e"
+       inkscape:connector-curvature="0"
+       d="m 470,206 v 86 h 145 v -86 z"
+       id="decoration-inactive-center" />
+    <g
+       transform="translate(145)"
+       id="decoration-inactive-top">
+      <g
+         id="g120">
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:0.85;fill:url(#linearGradient6612-5)"
+           id="path114"
+           d="M 525,5 V 40 H 670 V 5 Z"
+           transform="translate(-200,135)" />
+        <path
+           style="opacity:0.85"
+           inkscape:connector-curvature="0"
+           id="path116"
+           d="M 325,35 V 57 H 470 V 35 Z"
+           transform="translate(0,140)" />
+        <path
+           style="fill:#2d2d2d"
+           inkscape:connector-curvature="0"
+           id="path118"
+           d="m 325,176 v 30 h 145 v -30 z" />
+      </g>
+      <path
+         style="opacity:0.07999998;fill:#ffffff;fill-opacity:0.99492002"
+         inkscape:connector-curvature="0"
+         id="path122"
+         d="m 325,176 v 1 h 145 v -1 z" />
+    </g>
+    <g
+       transform="translate(120.12,8.9845)"
+       id="decoration-inactive-left">
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.85;fill:url(#linearGradient361)"
+         id="path125"
+         d="m 420,71.015 v 86 h 75 v -86 z"
+         transform="translate(-175.12,126)" />
+      <path
+         style="opacity:0.85"
+         inkscape:connector-curvature="0"
+         id="path127"
+         d="m 319.88,197.02 v 86 h 5 v -86 z" />
+      <path
+         style="fill:#3e3e3e"
+         inkscape:connector-curvature="0"
+         id="path129"
+         d="m 320.88,197.02 v 86 h 29 v -86 z" />
+    </g>
+    <g
+       id="decoration-inactive-bottomleft">
+      <g
+         id="g160"
+         transform="matrix(1,0,0,0.99932,140,-14.604)">
+        <path
+           inkscape:connector-curvature="0"
+           style="opacity:0.85;fill:url(#radialGradient363)"
+           id="path156"
+           d="m 365,202 v 91.937 l 105,0.0625 v -85.062 l -23.004,1e-5 c -3.8318,0 -6.919,-3.1113 -6.9922,-6.9258 l -0.004,-0.0117 z"
+           transform="matrix(1,0,0,1.0007,-140,104.68)" />
+        <g
+           id="g158"
+           transform="translate(-20,24)" />
+      </g>
+      <path
+         style="opacity:0.85"
+         inkscape:connector-curvature="0"
+         id="path162"
+         d="m 440,292.01 c 0.0338,3.8486 3.1392,7 6.9961,7 l 23,1e-5 v -1 h -23 c -3.324,0 -6,-2.676 -6,-6 z" />
+      <path
+         style="opacity:0.8;fill:#242424"
+         inkscape:connector-curvature="0"
+         id="path164"
+         d="m 441,292 c 0,3.324 2.676,6 6,6 h 23 v -6 z" />
+    </g>
+    <use
+       y="0"
+       x="0"
+       xlink:href="#decoration-inactive-left"
+       height="100%"
+       width="100%"
+       transform="matrix(-1,0,0,1,1085,0)"
+       id="decoration-inactive-right" />
+    <use
+       y="0"
+       x="0"
+       xlink:href="#decoration-inactive-bottomleft"
+       height="100%"
+       width="100%"
+       transform="matrix(-1,0,0,1,1085,0)"
+       id="decoration-inactive-bottomright" />
+    <g
+       id="decoration-inactive-topleft"
+       inkscape:label="#decoration-inactive-topleft"
+       transform="translate(140,-25.063)">
+      <path
+         inkscape:connector-curvature="0"
+         style="opacity:0.85;fill:url(#radialGradient365);fill-opacity:1;stroke:none"
+         d="m 518,54.9375 c -9.972,0 -18,8.028 -18,18 v 12 9 1 2 15 V 120 120.9375 121 h 75 V 120.9375 120 111.9375 95 c 0,-2.77 2.23,-5 5,-5 h 10 10 5 V 55 h -5 V 54.9375 H 590 V 55 h -10 v -0.0625 h -18 -2 z"
+         transform="translate(-275,110.063)"
+         id="rect6520-3-2-6" />
+      <g
+         inkscape:label="#g5343"
+         id="6utrh-9">
+        <g
+           id="decoration-toplefthaerty-5"
+           inkscape:label="#g5253"
+           transform="translate(0,1)">
+          <g
+             inkscape:label="#g6458"
+             transform="translate(-19,25)"
+             id="49093u-9">
+            <path
+               id="path1190"
+               d="m 325.23333,174.063 c -3.4348,0 -6.2,2.7652 -6.2,6.2 v 15.1125 0.0666 8.55123 1.00307 0.0666 h 24.8 H 349 V 203.99333 174.063 h -15.5 z"
+               style="opacity:0.85;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.0333333"
+               inkscape:connector-curvature="0" />
+            <path
+               inkscape:connector-curvature="0"
+               style="fill:#2d2d2d;fill-opacity:1;stroke:none;stroke-width:1"
+               d="m 447,86 c -3.324,0 -6,2.676 -6,6 v 14.625 0.0644 8.27539 0.97071 V 116 h 24 5 V 114.96484 86 h -15 z"
+               transform="translate(-121,89.063)"
+               id="rect5073-4-9-6" />
+            <path
+               inkscape:connector-curvature="0"
+               style="opacity:0.07999998;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1"
+               d="m 447,86 c -3.324,0 -6,2.676 -6,6 v 0.800781 C 441,89.587581 443.676,87 447,87 h 8 15 v -1 h -15 z"
+               transform="translate(-121,89.063)"
+               id="path1194" />
+          </g>
+        </g>
+      </g>
+    </g>
+    <use
+       x="0"
+       y="0"
+       xlink:href="#decoration-inactive-topleft"
+       id="decoration-inactive-topright"
+       transform="matrix(-1,0,0,1,1085,0)"
+       width="100%"
+       height="100%" />
   </g>
-  <use
-     x="0"
-     y="0"
-     xlink:href="#decoration-inactive-topleft"
-     id="decoration-inactive-topright"
-     transform="matrix(-1,0,0,1,1085,0)"
-     width="100%"
-     height="100%" />
 </svg>


### PR DESCRIPTION
I came up with a fix for the decoration rendering issue a few people have seen in the McMojave dark theme, outlined here: https://www.reddit.com/r/kde/comments/ejl3f3/how_to_remove_this_extra_space_on_all_windows_it/.

I don't know exactly why it was acting up, but I found rearranging the object stacking in the SVG seemed to do the trick.